### PR TITLE
Add functionality so ball bounces off both left and right paddles.

### DIFF
--- a/Pong1.py
+++ b/Pong1.py
@@ -95,3 +95,12 @@ while True:
     if ball.xcor() < -390:
         ball.goto(0, 0)
         ball.dx *= -1
+
+    #Paddle and ball collisions
+    if (ball.xcor() > 340 and ball.xcor() < 350) and (ball.ycor() < paddle_b.ycor() +40 and ball.ycor() > paddle_b.ycor() -40):
+        ball.setx(340)
+        ball.dx *= -1
+
+    if (ball.xcor() < -340 and ball.xcor() > -350) and (ball.ycor() < paddle_a.ycor() +40 and ball.ycor() > paddle_a.ycor() -40):
+        ball.setx(-340)
+        ball.dx *= -1


### PR DESCRIPTION
### What does this PR do?
- This PR adds functionality so the ball with deflect off of the top and bottom borders, as well as the 1st and 2nd player paddles.

### What does it fix?
- No bugs to fix at this time.

### Is this a feature or a fix?
- This is a feature.

### Where should the reviewer start?
- Clone down this repo.

### How should this be tested?
- In your terminal, change directory into pong-clone, and run "python Pong1.py" to bring up the game. Use "W" key for up and "S" key for down to control the left or player 1 paddle, and use "O" or "L" paddle to control the right or player 2 paddle, and notice the ball bounces off each paddle when it connects.
